### PR TITLE
Add English README with Vietnamese translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.1] - 2024-05-21
+
+### Added
+- English primary README with structured platform overview and workflow guidance.
+- Vietnamese translation stored in `docs/README.vi.md` with cross-links between languages.
+- Minimal `deny.toml` to share advisory database settings for `cargo deny`.
+
+### Changed
+- Highlighted security and dependency checks (`cargo audit`, `cargo deny`) in the quality gate section.
+
+## [0.1.0] - 2024-05-21
+
+### Added
+- Initial workspace layout, documentation, and examples for Zalo OA integration in Rust.
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "bot-axum"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "tracing",
  "zalo-bot",
@@ -264,7 +264,7 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miniapp-leptos"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "zalo-sdk",
 ]
@@ -833,7 +833,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zalo-bot"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "hex",
  "hmac",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "zalo-sdk"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "zalo-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "figment",
  "masterror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT OR Apache-2.0"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Zalo Bot Team <dev@zalo.ai>"]
 description = "Zalo bot platform implemented in Rust"
 

--- a/README.md
+++ b/README.md
@@ -1,92 +1,110 @@
 # Zalo Bot
 
-Проект нацелен на полноценную и безопасную интеграцию с Zalo Official Account (OA) API. Основной артефакт на текущем этапе — детализация требований к клиентской библиотеке бота и список API-методов, которые необходимо реализовать для полного покрытия возможностей официального API.
+> Production-ready, multilingual documentation for the Rust integration with the Zalo Official Account (OA) platform.
 
-## Обзор Zalo Official Account API
+**Translations:** [Tiếng Việt](docs/README.vi.md)
 
-- **Базовый URL**: `https://openapi.zalo.me/v3.0/oa/`. В большинстве методов путь продолжает этот префикс и уточняет домен (например, `message/cs`, `tag/gettagsofoa`).
-- **Типы сообщений**: Customer Service (`cs`), Transaction (`transaction`), Promotion (`promotion`). Выбор типа влияет на ограничения отправки и допустимый контент.
-- **Форматы контента**: текст, вложения с типами `image`, `file`, шаблоны (`template`) со списками элементов и кнопками.
-- **Заголовки запросов**: все вызовы требуют заголовка `access_token` с действительным OA Access Token и корректного `Content-Type` (`application/json` или `multipart/form-data`).
+## Project goals
 
-## Аутентификация и управление токенами
+This repository delivers a safe, end-to-end integration layer for the Zalo Official Account API. The current focus is to document
+all required capabilities, stabilise the Rust workspace layout, and provide building blocks for bots and mini apps that comply
+with the official platform policies.
 
-1. Создайте OA на [Zalo Business](https://business.zalo.me/).
-2. Зарегистрируйте приложение в [Zalo Developers](https://developers.zalo.me/) и получите App ID, Secret Key, OA ID и Access Token.
-3. Храните и обновляйте Access Token и Refresh Token — ошибки `-204` и `-240` сигнализируют об истечении токена либо необходимости перехода на API v3.
-4. Приём входящих событий настраивается через HTTPS вебхуки с проверкой MAC-подписи.
+## Zalo Official Account API overview
 
-## Ограничения платформы
+- **Base URL:** `https://openapi.zalo.me/v3.0/oa/`. Most endpoints extend this prefix with a domain-specific segment such as
+  `message/cs` or `tag/gettagsofoa`.
+- **Message types:** Customer Service (`cs`), Transaction (`transaction`), and Promotion (`promotion`). The chosen type affects
+  delivery constraints and permissible content.
+- **Content formats:** plain text, attachments (`image`, `file`), and list-based templates with buttons.
+- **Request headers:** each call must provide a valid OA `access_token` header and the appropriate `Content-Type` (`application/json`
+  or `multipart/form-data`).
 
-- **Лимиты**: типичные ограничения составляют 10 запросов в секунду на OA. Ошибка `-210` сигнализирует о превышении.
-- **Ограничение 24 часов**: сообщение за пределами 24-часового окна вызовет ошибку `-214`, поэтому необходимо вести учёт последнего контакта.
-- **Политики контента**: нарушение правил приводит к ошибке `-215`; стоит внедрять валидацию и модерацию сообщений до отправки.
+## Authentication and token lifecycle
 
-## Ключевые домены API
+1. Create an OA at [Zalo Business](https://business.zalo.me/).
+2. Register an app on [Zalo Developers](https://developers.zalo.me/) to obtain the App ID, Secret Key, OA ID, and Access Token.
+3. Store and rotate both the Access Token and Refresh Token. Errors `-204` and `-240` indicate an expired token or a required
+   migration to API v3.
+4. Configure HTTPS webhooks for inbound events and verify the MAC signature for every payload.
 
-| Домен | Ключевые endpoint'ы | Назначение |
+## Platform constraints
+
+- **Rate limiting:** typical OA quotas allow roughly 10 requests per second. Error `-210` indicates the limit was exceeded.
+- **24-hour messaging window:** sending a message beyond the 24-hour window triggers error `-214`; bots must track the latest
+  user interaction timestamp.
+- **Content policy enforcement:** violations result in error `-215`. Implement validation and moderation before dispatching
+  messages.
+
+## Key API domains
+
+| Domain | Representative endpoints | Purpose |
 | --- | --- | --- |
-| Сообщения | `message/{messageType}` | Текстовые сообщения, изображения, файлы, списки и шаблоны. |
-| Управление подписчиками | `getoa`, `getprofile`, `getfollowers`, `updatefollowerinfo` | Получение профилей, списка подписчиков и обновление данных. |
-| Диалоги | `listrecentchat`, `conversation` | Получение списка чатов и истории переписки. |
-| Медиа | `upload/image`, `upload/file`, `upload/gif` | Загрузка вложений для дальнейшей отправки. |
-| Теги | `tag/gettagsofoa`, `tag/tagfollower`, `tag/rmfollowerfromtag` | Управление тегами и сегментацией аудитории. |
-| Контент OA | `article/create`, `article/upload_video/*`, `article/verify` | Публикация статей, работа с видео и проверка статей. |
-| Магазин | `store/product/*`, `store/order/*` | Управление товарами и заказами OA Store. |
-| Вебхук | Пользовательский URL | Приём событий: follow/unfollow, сообщения, клики, подтверждение MAC. |
+| Messaging | `message/{messageType}` | Text, media, list, and template message delivery. |
+| Subscriber management | `getoa`, `getprofile`, `getfollowers`, `updatefollowerinfo` | Access OA profiles, follower lists, and update metadata. |
+| Conversations | `listrecentchat`, `conversation` | Retrieve chat lists and conversation history. |
+| Media | `upload/image`, `upload/file`, `upload/gif` | Upload attachments for later use. |
+| Tags | `tag/gettagsofoa`, `tag/tagfollower`, `tag/rmfollowerfromtag` | Manage audience segmentation through tags. |
+| OA content | `article/create`, `article/upload_video/*`, `article/verify` | Publish articles, manage videos, and verify drafts. |
+| Store | `store/product/*`, `store/order/*` | Maintain OA Store products and orders. |
+| Webhook | Custom URL | Receive follow/unfollow events, inbound messages, clicks, and MAC verification callbacks. |
 
-Полный перечень методов и структур поддерживается в [`docs/progress.md`](docs/progress.md).
+A detailed checklist of methods and data contracts lives in [`docs/progress.md`](docs/progress.md).
 
-## Вебхуки и события
+## Webhooks and events
 
-Вебхук OA принимает POST-запросы с полями `app_id`, `sender.id`, `recipient.id`, `event_name`, `timestamp`, `message` и `mac`. Нужно реализовать проверку подписи и поддержку событий:
+OA webhooks receive POST payloads containing `app_id`, `sender.id`, `recipient.id`, `event_name`, `timestamp`, `message`, and `mac`.
+The integration must verify the MAC signature and support the following events:
 
-- **Пользовательские события**: `follow`, `unfollow`.
-- **Сообщения**: `user_send_text`, `user_send_image`, `user_send_file`, `user_send_sticker`, `user_send_gif`, `user_send_location`.
-- **Интеракции**: `user_click_link`, `user_click_button`, `user_received_message`, `user_seen_message`.
+- **User lifecycle:** `follow`, `unfollow`.
+- **Messaging:** `user_send_text`, `user_send_image`, `user_send_file`, `user_send_sticker`, `user_send_gif`, `user_send_location`.
+- **Interactions:** `user_click_link`, `user_click_button`, `user_received_message`, `user_seen_message`.
 
-## Диагностика и обработка ошибок
+## Diagnostics and error handling
 
-Распространённые коды ошибок Zalo OA API:
+Common Zalo OA API error codes:
 
-| Код | Значение |
+| Code | Meaning |
 | --- | --- |
-| `-201` | Отсутствуют обязательные параметры. |
-| `-202` | Неверные значения параметров. |
-| `-204` | Недействительный или истёкший Access Token. |
-| `-205` | Недостаточно прав у OA. |
-| `-210` | Превышен rate limit. |
-| `-211` | OA не прошёл верификацию. |
-| `-213` | Пользователь не подписан на OA. |
-| `-214` | Сообщение отправлено вне 24-часового окна. |
-| `-215` | Контент нарушает политику. |
-| `-216` | Дубликат сообщения. |
-| `-240` | Используется устаревший API v2. |
+| `-201` | Required parameters are missing. |
+| `-202` | Parameter values are invalid. |
+| `-204` | Access Token is invalid or expired. |
+| `-205` | OA lacks sufficient permissions. |
+| `-210` | Rate limit exceeded. |
+| `-211` | OA failed verification. |
+| `-213` | User is not subscribed to the OA. |
+| `-214` | Message sent outside the 24-hour window. |
+| `-215` | Content violates platform policies. |
+| `-216` | Duplicate message detected. |
+| `-240` | Legacy API v2 is in use and must be upgraded. |
 
-## Как пользоваться репозиторием
+## How to work with this repository
 
-- Переходите в [`docs/progress.md`](docs/progress.md), чтобы отслеживать закрытие каждого endpoint'а и связанной бизнес-логики.
-- Добавляйте ADR и примеры при реализации подсистем, чтобы документировать архитектурные решения и сценарии отказов.
-- Перед реализацией конкретного метода проверяйте требования по аутентификации, лимитам и формату данных для выбранного домена.
+- Track endpoint coverage and required business logic in [`docs/progress.md`](docs/progress.md).
+- Contribute ADRs and runnable examples alongside subsystem implementations to document architectural decisions and failure modes.
+- Before coding against a specific endpoint, review authentication requirements, rate limits, and payload formats for the
+  corresponding domain.
 
-## Rust-платформа
+## Rust workspace structure
 
-Репозиторий собран как многокорневой workspace:
+This repository is organised as a multi-crate workspace:
 
-- `crates/zalo-types` — общие типы, конфигурация (`ConfigLoader`) и маппинг ошибок на [`masterror`](https://crates.io/crates/masterror).
-- `crates/zalo-sdk` — лёгкий SDK для Mini App (валидация контекста, генерация handshake-пейлоада).
-- `crates/zalo-bot` — утилиты для OA Bot: инициализация логирования (`init_tracing`) и проверка вебхук-подписей (`WebhookVerifier`).
-- `examples/miniapp-leptos` — демонстрация использования SDK на стороне Mini App.
-- `examples/bot-axum` — пример инициализации вебхука на базе `zalo-bot`.
+- `crates/zalo-types` — shared types, configuration loader (`ConfigLoader`), and error mapping built on [`masterror`](https://crates.io/crates/masterror).
+- `crates/zalo-sdk` — lightweight Mini App SDK providing context validation and handshake payload generation.
+- `crates/zalo-bot` — OA bot utilities: tracing initialisation (`init_tracing`) and webhook signature verification (`WebhookVerifier`).
+- `examples/miniapp-leptos` — sample Mini App that demonstrates SDK usage.
+- `examples/bot-axum` — webhook bootstrap example powered by `zalo-bot`.
 
-### Конфигурация
+### Configuration
 
-`ConfigLoader` по умолчанию читает переменные окружения с префиксом `ZALO_BOT_` и необязательный TOML-файл. Поддерживаются секции:
+`ConfigLoader` reads environment variables prefixed with `ZALO_BOT_` and an optional TOML file. Supported sections:
 
-- `environment` — `development` | `staging` | `production`.
-- `[logging]` — поля `filter` (выражение для `tracing_subscriber::EnvFilter`) и `format` (`text` или `json`).
+- `environment` — one of `development`, `staging`, or `production`.
+- `[logging]` — fields `filter` (expression for `tracing_subscriber::EnvFilter`) and `format` (`text` or `json`).
 
-### Проверка качества
+### Quality gates
+
+Run the following commands before submitting changes to guarantee consistent formatting, linting, tests, and documentation:
 
 ```
 cargo +nightly fmt --
@@ -95,4 +113,5 @@ cargo test --all
 cargo doc --no-deps
 ```
 
-Эти команды обязательны перед публикацией изменений: форматирование, линтинг, тесты и генерация документации должны проходить без ошибок.
+Security and dependency hygiene checks use `cargo audit` and `cargo deny`.
+

--- a/crates/zalo-bot/src/webhook.rs
+++ b/crates/zalo-bot/src/webhook.rs
@@ -58,8 +58,7 @@ impl WebhookVerifier {
         let signature = signature.ok_or(SignatureError::Missing)?;
         let signature_bytes =
             hex::decode(signature).map_err(|_| SignatureError::VerificationFailed)?;
-        let mut mac =
-            HmacSha256::new_from_slice(&self.secret).map_err(SignatureError::from)?;
+        let mut mac = HmacSha256::new_from_slice(&self.secret).map_err(SignatureError::from)?;
         mac.update(payload);
         mac.verify_slice(&signature_bytes)
             .map_err(|_| SignatureError::VerificationFailed)?;

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,12 @@
+[advisories]
+db-path = "$CARGO_HOME"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+
+[licenses]
+allow = ["MIT", "Apache-2.0", "BSD-3-Clause", "Unicode-3.0"]
+
+[bans]
+multiple-versions = "warn"
+
+[sources]
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/docs/README.vi.md
+++ b/docs/README.vi.md
@@ -1,0 +1,113 @@
+# Zalo Bot
+
+> Tài liệu đa ngôn ngữ cho lớp tích hợp Zalo Official Account (OA) viết bằng Rust.
+
+**Ngôn ngữ khác:** [English](../README.md)
+
+## Mục tiêu dự án
+
+Kho mã này xây dựng lớp tích hợp an toàn, toàn diện cho Zalo Official Account API. Trọng tâm hiện tại là ghi lại đầy đủ các khả
+ăng cần thiết, ổn định cấu trúc workspace Rust và cung cấp các khối xây dựng cho bot và mini app tuân thủ chính sách chính thức
+của nền tảng.
+
+## Tổng quan Zalo Official Account API
+
+- **Base URL:** `https://openapi.zalo.me/v3.0/oa/`. Hầu hết endpoint sẽ nối thêm đoạn đường dẫn theo từng miền như `message/cs`
+  hoặc `tag/gettagsofoa`.
+- **Loại tin nhắn:** Customer Service (`cs`), Transaction (`transaction`) và Promotion (`promotion`). Lựa chọn này ảnh hưởng tới
+  giới hạn gửi và loại nội dung được phép.
+- **Định dạng nội dung:** văn bản thuần, tệp đính kèm (`image`, `file`) và các mẫu (template) dạng danh sách với nút bấm.
+- **Header yêu cầu:** mỗi lệnh gọi phải có header `access_token` hợp lệ của OA và `Content-Type` phù hợp (`application/json`
+  hoặc `multipart/form-data`).
+
+## Xác thực và vòng đời token
+
+1. Tạo OA trên [Zalo Business](https://business.zalo.me/).
+2. Đăng ký ứng dụng tại [Zalo Developers](https://developers.zalo.me/) để lấy App ID, Secret Key, OA ID và Access Token.
+3. Lưu trữ và xoay vòng Access Token lẫn Refresh Token. Lỗi `-204` và `-240` báo hiệu token hết hạn hoặc cần nâng cấp lên API v3.
+4. Cấu hình webhook HTTPS cho sự kiện đến và xác minh chữ ký MAC cho mọi payload.
+
+## Giới hạn nền tảng
+
+- **Giới hạn tần suất:** hạn ngạch phổ biến cho OA khoảng 10 yêu cầu mỗi giây. Lỗi `-210` nghĩa là đã vượt giới hạn.
+- **Cửa sổ tin nhắn 24 giờ:** gửi tin vượt quá 24 giờ kể từ lần tương tác cuối sẽ sinh lỗi `-214`; bot cần lưu dấu thời điểm tương tác mới nhất.
+- **Tuân thủ chính sách nội dung:** vi phạm sẽ trả về lỗi `-215`. Cần kiểm tra và kiểm duyệt thông điệp trước khi gửi.
+
+## Các miền API chính
+
+| Miền | Endpoint tiêu biểu | Mục đích |
+| --- | --- | --- |
+| Nhắn tin | `message/{messageType}` | Gửi tin văn bản, media, danh sách và template. |
+| Quản lý người theo dõi | `getoa`, `getprofile`, `getfollowers`, `updatefollowerinfo` | Lấy thông tin OA, danh sách follower và cập nhật metadata. |
+| Hội thoại | `listrecentchat`, `conversation` | Lấy danh sách chat và lịch sử hội thoại. |
+| Media | `upload/image`, `upload/file`, `upload/gif` | Tải tệp đính kèm để sử dụng sau. |
+| Thẻ (tag) | `tag/gettagsofoa`, `tag/tagfollower`, `tag/rmfollowerfromtag` | Quản lý phân khúc người dùng bằng tag. |
+| Nội dung OA | `article/create`, `article/upload_video/*`, `article/verify` | Xuất bản bài viết, quản lý video và kiểm duyệt bản nháp. |
+| Cửa hàng | `store/product/*`, `store/order/*` | Quản lý sản phẩm và đơn hàng trên OA Store. |
+| Webhook | URL tuỳ chỉnh | Nhận sự kiện follow/unfollow, tin nhắn đến, click và xác minh MAC. |
+
+Danh sách nhiệm vụ chi tiết cho phương thức và hợp đồng dữ liệu nằm tại [`docs/progress.md`](progress.md).
+
+## Webhook và sự kiện
+
+Webhook của OA nhận payload POST gồm `app_id`, `sender.id`, `recipient.id`, `event_name`, `timestamp`, `message` và `mac`. Lớp
+ tích hợp cần xác minh chữ ký MAC và hỗ trợ các sự kiện sau:
+
+- **Vòng đời người dùng:** `follow`, `unfollow`.
+- **Tin nhắn:** `user_send_text`, `user_send_image`, `user_send_file`, `user_send_sticker`, `user_send_gif`, `user_send_location`.
+- **Tương tác:** `user_click_link`, `user_click_button`, `user_received_message`, `user_seen_message`.
+
+## Chẩn đoán và xử lý lỗi
+
+Các mã lỗi phổ biến của Zalo OA API:
+
+| Mã | Ý nghĩa |
+| --- | --- |
+| `-201` | Thiếu tham số bắt buộc. |
+| `-202` | Giá trị tham số không hợp lệ. |
+| `-204` | Access Token không hợp lệ hoặc đã hết hạn. |
+| `-205` | OA không đủ quyền. |
+| `-210` | Vượt quá giới hạn tần suất. |
+| `-211` | OA không vượt qua bước xác minh. |
+| `-213` | Người dùng chưa theo dõi OA. |
+| `-214` | Tin gửi ngoài cửa sổ 24 giờ. |
+| `-215` | Nội dung vi phạm chính sách. |
+| `-216` | Tin nhắn trùng lặp. |
+| `-240` | Đang dùng API v2 cũ, cần nâng cấp. |
+
+## Làm việc với kho mã
+
+- Theo dõi phạm vi endpoint và logic liên quan trong [`docs/progress.md`](progress.md).
+- Khi xây dựng subsystem, bổ sung ADR và ví dụ có thể chạy để ghi lại quyết định kiến trúc và kịch bản lỗi.
+- Trước khi lập trình theo endpoint cụ thể, hãy kiểm tra yêu cầu xác thực, giới hạn tần suất và định dạng payload cho miền tương ứng.
+
+## Cấu trúc workspace Rust
+
+Kho mã được tổ chức thành workspace nhiều crate:
+
+- `crates/zalo-types` — các kiểu dùng chung, bộ nạp cấu hình (`ConfigLoader`) và ánh xạ lỗi dựa trên [`masterror`](https://crates.io/crates/masterror).
+- `crates/zalo-sdk` — SDK gọn nhẹ cho Mini App, hỗ trợ kiểm tra ngữ cảnh và sinh handshake payload.
+- `crates/zalo-bot` — tiện ích cho OA bot: khởi tạo tracing (`init_tracing`) và xác minh chữ ký webhook (`WebhookVerifier`).
+- `examples/miniapp-leptos` — ví dụ Mini App minh hoạ cách dùng SDK.
+- `examples/bot-axum` — ví dụ khởi tạo webhook bằng `zalo-bot`.
+
+### Cấu hình
+
+`ConfigLoader` đọc biến môi trường với tiền tố `ZALO_BOT_` và (nếu có) tệp TOML. Các phần được hỗ trợ:
+
+- `environment` — một trong `development`, `staging` hoặc `production`.
+- `[logging]` — trường `filter` (biểu thức cho `tracing_subscriber::EnvFilter`) và `format` (`text` hoặc `json`).
+
+### Quy trình kiểm soát chất lượng
+
+Chạy các lệnh sau trước khi gửi thay đổi để đảm bảo định dạng, lint, kiểm thử và tài liệu nhất quán:
+
+```
+cargo +nightly fmt --
+cargo clippy -D warnings
+cargo test --all
+cargo doc --no-deps
+```
+
+Kiểm tra bảo mật và phụ thuộc sử dụng `cargo audit` và `cargo deny`.
+


### PR DESCRIPTION
## Summary
- replace the top-level README with an English-first version and link to a Vietnamese translation
- add the Vietnamese README, changelog entry, and bump the workspace version to 0.1.1
- provide a minimal cargo-deny configuration so dependency checks succeed locally

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check --disable-fetch

------
https://chatgpt.com/codex/tasks/task_e_68cdeb0a2c5c832b9e44b0f0f036a7b4